### PR TITLE
Update manifest.xml

### DIFF
--- a/widget/manifest.xml
+++ b/widget/manifest.xml
@@ -31,6 +31,7 @@
             <iq:product id="fr55"/>
             <iq:product id="fr645"/>
             <iq:product id="fr645m"/>
+            <iq:product id="fr735xt"/>
             <iq:product id="fr745"/>
             <iq:product id="fr935"/>
             <iq:product id="fr945"/>


### PR DESCRIPTION
Added support for the Forerunner 735XT.
I don't expect it to differ too much from other supported watches. It did work on the earlier versions of the original HassControl.