### PR TITLE
Fix cover actions

### DIFF
--- a/widget/source/hass/Client.mc
+++ b/widget/source/hass/Client.mc
@@ -142,10 +142,18 @@ module Hass {
                 serviceAction = "turn_off";
                 newState = "off";
             } else if (action == Client.ENTITY_ACTION_CLOSE) {
-                serviceAction = "close";
+                if (entityType == "cover") {
+                    serviceAction = "close_cover";
+                } else {
+                    serviceAction = "close";
+                }
                 newState = "closed";
             } else if (action == Client.ENTITY_ACTION_OPEN) {
-                serviceAction = "open";
+                if (entityType == "cover") {
+                    serviceAction = "open_cover";
+                } else {
+                    serviceAction = "open";
+                }
                 newState = "open";
             } else if (action == Client.ENTITY_ACTION_LOCK) {
                 serviceAction = "lock";


### PR DESCRIPTION
Unfortunately, f8761caa8c97d9b050dcdeec7041e554270ddc16 broke support for covers because it changed the service action from the `{open,close}_cover` variants to just `open,close`.

In the interest of transparency, I haven't tested this as I currently don't have a working setup to do so.

I went for the most basic fix imaginable by just adding some extra logic to the `setEntityState` function. I did consider some alternatives:

- Extend the action enum to add back `ENTITY_ACTION_{OPEN,CLOSE}_COVER`. I feel like this isn't ideal because we _want_ the action to be 'open' or 'close'. It's just an unfortunate Home Assistant implementation detail that the same action has different names depending on the domain.
- I think the implementation could be slightly improved by passing the entity type as the `Entity.TYPE_*` enum rather than as a string. The code could then compare against `Entity.TYPE_COVER` instead of the magic string `"cover"`.

Since I can't test my changes and I'm not very familiar with the abomination that is Monkey C I decided against them, but do let me know if you want me to go with an alternative approach.