### PR TITLE
Handle transitional states for covers

### DIFF
--- a/widget/source/hass/Constants.mc
+++ b/widget/source/hass/Constants.mc
@@ -5,7 +5,9 @@ module Hass {
     const HASS_STATE_OFF = "off";
     const HASS_STATE_LOCKED = "locked";
     const HASS_STATE_UNLOCKED = "unlocked";
+    const HASS_STATE_OPENING = "opening";
     const HASS_STATE_OPEN = "open";
+    const HASS_STATE_CLOSING = "closing";
     const HASS_STATE_CLOSED = "closed";
     const HASS_STATE_UNKNOWN = "unknown";
 

--- a/widget/source/hass/Entity.mc
+++ b/widget/source/hass/Entity.mc
@@ -27,10 +27,10 @@ module Hass {
       if (HASS_STATE_UNLOCKED.equals(stateInText)) {
         return STATE_UNLOCKED;
       }
-      if (HASS_STATE_OPEN.equals(stateInText)) {
+      if (HASS_STATE_OPEN.equals(stateInText) || HASS_STATE_OPENING.equals(stateInText)) {
         return STATE_OPEN;
       }
-      if (HASS_STATE_CLOSED.equals(stateInText)) {
+      if (HASS_STATE_CLOSED.equals(stateInText) || HASS_STATE_CLOSING.equals(stateInText)) {
         return STATE_CLOSED;
       }
 


### PR DESCRIPTION
Home Assistant officially recognizes `opening` and `closing` as valid states for covers: https://developers.home-assistant.io/docs/core/entity/cover/#states.
Right now these states cause the widget to display an unknown state.
This PR changes that so the transitional states are at least mapped to their equivalent stable state.

As with #56, I haven't tested this.