### PR TITLE
Sanitise Host URL 

### DIFF
--- a/widget/source/hass/Client.mc
+++ b/widget/source/hass/Client.mc
@@ -37,7 +37,7 @@ module Hass {
         }
 
         function refreshBaseUrl() {
-            var newUrl = App.Properties.getValue("host");
+            var newUrl = App.Properties.getValue("host").trim();
             var chars = newUrl.toCharArray();
 
             if (chars.size() < 8) {


### PR DESCRIPTION
Trim host URL. 

When a user copy-pastes a URL, sometimes a space is added, causing the URL to be invalid on refresh, this fixes that giving a smoother user experience.