### PR TITLE
Using device night mode settings to determine glance colors

### DIFF
--- a/widget/source/AppGlance.mc
+++ b/widget/source/AppGlance.mc
@@ -1,4 +1,5 @@
 using Toybox.WatchUi as Ui;
+using Toybox.System as System;
 using Hass;
 using Utils;
 
@@ -25,12 +26,19 @@ class AppGlance extends Ui.GlanceView {
     var textDimensions = dc.getTextDimensions(text, font);
     var textHeight = textDimensions[1];
 
+    
+    var bg = System.getDeviceSettings().isNightModeEnabled ? Graphics.COLOR_BLACK : Graphics.COLOR_WHITE;
+    var fg = bg == Graphics.COLOR_BLACK ? Graphics.COLOR_WHITE : Graphics.COLOR_BLACK;
+
+    dc.setColor(bg, bg);
+    dc.clear();
+
+    dc.setColor(fg,bg);
+
     // Adjust text position based on screen shape
     if (Utils.isRectangularScreen()) {
-      dc.setColor(Graphics.COLOR_WHITE, Graphics.COLOR_BLACK);
       dc.drawText(10, (height / 2) - (textHeight / 2), font, text, Graphics.TEXT_JUSTIFY_LEFT);
     } else {
-      dc.setColor(Graphics.COLOR_WHITE, Graphics.COLOR_BLACK);
       dc.drawText(5, (height / 2) - (textHeight / 2), font, text, Graphics.TEXT_JUSTIFY_LEFT);
     }
   }


### PR DESCRIPTION
WIthout this, I get the dark mode only for the hasscontrol glance, while everything else is in light mode. I tested this on my Edge Explore 2 and it works perfectly (in the simulator there is a weird behaviour when selecting night/day mode where only the area around the glance title changes colour, but on real devices it works as expected)