### PR TITLE
ci: bump actions/checkout to v7 and actions/setup-java to v5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,12 +8,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v7
 
-    - name: Set up JDK 1.8
-      uses: actions/setup-java@v1
+    - name: Set up JDK 8
+      uses: actions/setup-java@v5
       with:
-        java-version: 1.8
+        distribution: temurin
+        java-version: 8
 
     - name: Get devices
       run: |


### PR DESCRIPTION
## Summary

CI currently warns on every run:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: actions/checkout@v3, actions/setup-java@v1.

This bumps both actions to their current majors:

- `actions/checkout` v3 → **v7**
- `actions/setup-java` v1 → **v5** — v2+ requires an explicit `distribution`; kept JDK 8 via Temurin (same as the previous `1.8`)

No other workflow changes.

## Testing

Workflow ran green on my fork with these versions (same `monkeyc` build, warning gone).
