### PR TITLE
Fix lowmem key bump, cold-start self-heal crash, and unavailable-state crash

### DIFF
--- a/widget/source/App.mc
+++ b/widget/source/App.mc
@@ -148,8 +148,10 @@ class HassControlApp extends App.AppBase {
         // the cache): a state refresh walks an empty list and completes
         // instantly without a single request, so import the group instead.
         // importEntities() ends by starting the same refresh, so this also
-        // covers the state fill the call below would have done.
-        Hass.importEntities();
+        // covers the state fill the call below would have done. No view
+        // has been pushed yet at this point in getInitialView(), so the
+        // loader must stay off - see importEntities()'s comment.
+        Hass.importEntities(false);
       } else {
         Hass.refreshAllEntities(true);
       }

--- a/widget/source/Menu/MenuDelegate.mc
+++ b/widget/source/Menu/MenuDelegate.mc
@@ -71,7 +71,7 @@ class MenuDelegate extends Ui.Menu2InputDelegate {
             return true;
         }
         if (itemId == MenuController.MENU_REFRESH_ENTITIES) {
-            Hass.importEntities();
+            Hass.importEntities(true);
             return true;
         }
 

--- a/widget/source/Utils.mc
+++ b/widget/source/Utils.mc
@@ -543,8 +543,17 @@ module Utils {
 
   // Formats a numeric entity value (input_number/number) to the decimal
   // precision implied by its step, instead of the raw float representation.
+  // A HA state isn't always a number (e.g. "unavailable"/"unknown" during a
+  // refresh) - toFloat() returns null for those, which would crash on
+  // .format(); fall back to the raw value rather than formatting it.
   (:fullmem)
   function formatNumberForStep(value, step) {
-    return value.toFloat().format("%." + decimalPlacesForStep(step) + "f");
+    var num = value.toFloat();
+
+    if (num == null) {
+      return value;
+    }
+
+    return num.format("%." + decimalPlacesForStep(step) + "f");
   }
 }

--- a/widget/source/hass/Entity.mc
+++ b/widget/source/hass/Entity.mc
@@ -27,13 +27,12 @@ module Hass {
     (:lowmem)
     static const STORED_FIELDS = 6;
 
-    // Field count of the pre-2.2.0 flat storage format, kept for the one-time
-    // migration in Hass.loadStoredEntities(). 2.2.0's :fullmem stride grew
-    // from 6 to 10 to persist select's options and input_number/number's
-    // min/max/step. The v2 layout (id, name, state, sensorClass, icon,
-    // deviceClass) matches today's :lowmem STORED_FIELDS exactly, so the
-    // reader below is untagged and compiles on both tiers - the :lowmem
-    // createFromStorage is already the same code, just private to that tier.
+    // Field count of the pre-2.2.0 flat storage format, kept for the
+    // one-time :fullmem migration in Hass.loadStoredEntities(). :fullmem's
+    // stride grew from 6 to 10 to persist select's options and
+    // input_number/number's min/max/step; :lowmem's never changed, so it
+    // has nothing to migrate (see Hass.STORAGE_KEY) and doesn't need this.
+    (:fullmem)
     static const STORED_FIELDS_V2 = 6;
 
     // Appends this entity at `offset` and returns the next free offset.
@@ -110,10 +109,12 @@ module Hass {
     }
 
     // Reads one entity from the pre-2.2.0 flat format (6 slots per entity,
-    // keyed under "Hass/entities/v2"). Only used by the one-time migration
-    // in Hass.loadStoredEntities(). The extended fields (options, min, max,
-    // step) don't exist in v2 and are left null here; the next entity refresh
-    // repopulates them from the live state via _applyExtendedAttributes().
+    // keyed under "Hass/entities/v2"). Only used by the one-time :fullmem
+    // migration in Hass.loadStoredEntities(). The extended fields (options,
+    // min, max, step) don't exist in v2 and are left null here; the next
+    // entity refresh repopulates them from the live state via
+    // _applyExtendedAttributes().
+    (:fullmem)
     static function createFromV2Storage(stored, offset) {
       var id = stored[offset];
 

--- a/widget/source/hass/Hass.mc
+++ b/widget/source/hass/Hass.mc
@@ -12,15 +12,21 @@ module Hass {
   // (see Entity.mc). Bumped so a :fullmem device never misreads an old
   // v2 (6-field) array with the new 10-field stride - offset math would
   // silently pull the next entity's id/name into this one's tail fields.
-  // :lowmem's stride never changed (still 6), so it isn't actually at risk
-  // here, but shares the bump anyway rather than tracking two key versions.
+  // :lowmem's stride never changed (still 6), so it stays on v2 below -
+  // bumping it too would force every lowmem install to migrate for a
+  // format change that never applied to it.
+  (:fullmem)
   const STORAGE_KEY = "Hass/entities/v3";
 
-  // The pre-2.2.0 flat-array key. 2.2.0 bumped to v3 without a reader for
-  // v2, so a 2.1.0 -> 2.2.0 update lost the whole entity list
-  // ("No entities configured", startup refresh walking an empty list).
-  // loadStoredEntities() migrates v2 once, then deletes the key.
+  // The pre-2.2.0 flat-array key, read by loadStoredEntities()'s one-time
+  // migration below. :fullmem-only: on :lowmem, STORAGE_KEY is already
+  // this same key (see above), so there's nothing to migrate from.
+  (:fullmem)
   const STORAGE_KEY_V2 = "Hass/entities/v2";
+
+  (:lowmem)
+  const STORAGE_KEY = "Hass/entities/v2";
+
   const STORAGE_KEY_LEGACY = "Hass/entities";
 
   var client = null;
@@ -183,6 +189,9 @@ module Hass {
     }
   }
 
+  // :fullmem needs the v2 -> v3 migration below; :lowmem's STORAGE_KEY is
+  // already v2, so there's nothing to migrate and it keeps the plain read.
+  (:fullmem)
   function loadStoredEntities() {
     _entities = new [0];
 
@@ -215,11 +224,35 @@ module Hass {
     Utils.debugLog("Loaded entities: ", _entities.size(), " total");
   }
 
+  (:lowmem)
+  function loadStoredEntities() {
+    _entities = new [0];
+
+    var stored = App.Storage.getValue(STORAGE_KEY);
+
+    if (stored == null) {
+      _loadLegacyStoredEntities();
+    } else {
+      for (var i = 0; i + Entity.STORED_FIELDS <= stored.size(); i += Entity.STORED_FIELDS) {
+        var entity = Entity.createFromStorage(stored, i);
+        // Filter out null entities (from corrupted or invalid data)
+        if (entity != null) {
+          _entities.add(entity);
+        }
+      }
+    }
+
+    loadScenesFromSettings();
+
+    Utils.debugLog("Loaded entities: ", _entities.size(), " total");
+  }
+
   // Reads the 2.1.0-era flat array (Entity.STORED_FIELDS_V2 slots per
   // entity) and rewrites it under the current key. 2.2.0 bumped the key
   // without a migration, which made the 2.1.0 -> 2.2.0 update show
   // "No entities configured" with a startup refresh that walks an empty
   // list - the data was orphaned, not gone, so this recovers it.
+  (:fullmem)
   function _migrateV2Entities() {
     var stored = App.Storage.getValue(STORAGE_KEY_V2);
 
@@ -653,7 +686,15 @@ module Hass {
     }
   }
 
-  function importEntities() {
+  // showLoaderUi must be false when called from App.getInitialView()'s
+  // cold-start self-heal (see below) - the runtime hasn't pushed the
+  // initial view onto the Ui stack yet at that point, and showLoader()'s
+  // Ui.pushView() destabilizes the simulator (and, going by the crash
+  // shape, likely real hardware too) once enough Ui.requestUpdate() calls
+  // land during the refresh that follows. The initial view already shows
+  // "No entities" and updates once data arrives, so no loader is needed
+  // there anyway.
+  function importEntities(showLoaderUi) {
     Utils.logMem("importEntities:enter", null);
     var group = getGroup();
 
@@ -662,7 +703,9 @@ module Hass {
       return;
     }
 
-    App.getApp().viewController.showLoader("Refreshing");
+    if (showLoaderUi) {
+      App.getApp().viewController.showLoader("Refreshing");
+    }
 
     client.getEntity(group, null, Utils.method(Hass, :_onReceiveEntities));
   }


### PR DESCRIPTION
Depends on / builds on top of #103's v2 -> v3 migration.

## Summary
- `:lowmem`'s storage stride never changed, so it stays on the v2 key instead of migrating for a format change that never applied to it.
- Found and fixed a real crash in #103's self-healing `importEntities()` call from `getInitialView()`: `showLoader()`'s `Ui.pushView()` runs before the runtime has ever pushed the initial view onto the stack, since this call site is reached before `getInitialView()` returns (a different context than `importEntities()`'s other call site, the settings menu, where a view stack already exists). This reproducibly crashed the simulator partway through a real ~16-entity refresh. Added a `showLoaderUi` parameter to `importEntities()` and pass `false` from the cold-start call - the initial view already shows "No entities" and updates once data arrives, so no loader is needed there.
- `input_number`/`number` formatting assumed the HA state was always numeric, but `"unavailable"`/`"unknown"` are normal transient states - `toFloat()` returns `null` for those and `.format()` on `null` crashed. Falls back to the raw value when it isn't a parseable number.

## Test plan
- [x] Verified `:fullmem` and `:lowmem` both build clean
- [x] Seeded real v2.1.0-era v2 data (old build + manual refresh), then confirmed the fixed build migrates it to v3 and completes a full live refresh with no crash
- [x] Confirmed the cold-start self-heal path (empty storage, logged in, group configured) completes a full ~16-entity live refresh with no crash, including select/input_number entities
- [x] Reproduced a real `"unavailable"` entity state against a real Home Assistant server on a real fenix7x and confirmed it now displays "unavailable" instead of crashing